### PR TITLE
Ensure removal of outdated/obsolete raster tiles 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+code/data
+code/build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 data/
 download_data.log
 
+code/build

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,0 @@
-snowdepth.us
-proxy / 127.0.0.1:8080 {
-    transparent
-}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 #install prerequisites
 RUN apt-get -q update && \
-    apt-get -q -y install software-properties-common git python3.6 python3-pip \
-    build-essential unzip libsqlite3-dev zlib1g-dev wget curl && \
+    apt-get -q -y install awscli software-properties-common git python3.6 \
+    python3-pip build-essential unzip libsqlite3-dev zlib1g-dev wget curl && \
     add-apt-repository ppa:ubuntugis/ppa && \
     apt-get update && \
     apt-get -q -y install gdal-bin gdal-data && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+from ubuntu:18.04
+ENV DEBIAN_FRONTEND=noninteractive
+
+#install prerequisites
+RUN apt-get -q update && \
+    apt-get -q -y install software-properties-common git python3.6 python3-pip \
+    build-essential unzip libsqlite3-dev zlib1g-dev wget curl && \
+    add-apt-repository ppa:ubuntugis/ppa && \
+    apt-get update && \
+    apt-get -q -y install gdal-bin gdal-data && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/ /var/cache/apt/ /var/cache/debconf/
+
+RUN cd /opt && \
+    git clone -b '0.3' --single-branch --depth 1 \
+    https://github.com/OpenBounds/Processing.git && \
+    cd Processing && \
+    pip3 install click boto boto3 ujson requests
+
+ADD code /opt/snowdepth/
+
+ENV LC_ALL=C.UTF-8
+CMD ["/bin/bash","-c","cd /opt/snowdepth/ && ./download_data.sh || curl -X POST -H 'Content-type: application/json' --data '{\"text\":\"Snow build failed\"}' $SLACK_WEBHOOK"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ RUN cd /opt && \
 ADD code /opt/snowdepth/
 
 ENV LC_ALL=C.UTF-8
-CMD ["/bin/bash","-c","cd /opt/snowdepth/ && ./download_data.sh || curl -X POST -H 'Content-type: application/json' --data '{\"text\":\"Snow build failed\"}' $SLACK_WEBHOOK"]
+CMD ["/bin/bash","-c","cd /opt/snowdepth/ && ./download_data.sh || curl -X POST -H 'Content-type: application/json' --data '{\"text\":\"Snow depth build failed\"}' $SLACK_WEBHOOK"]

--- a/code/download_data.sh
+++ b/code/download_data.sh
@@ -35,7 +35,7 @@ popd
 mkdir -p build
 # Create MBTiles from SNODAS Snow Depth
 gdaldem color-relief data/$SD_FILE.Hdr colors.txt build/snow_depth.tiff -of GTiff -alpha
-gdal_translate build/snow_depth.tiff build/snow_depth.mbtiles
+gdal_translate build/snow_depth.tiff build/snow_depth.mbtiles -co ZOOM_LEVEL_STRATEGY=upper
 gdaladdo -r average build/snow_depth.mbtiles
 
 if [[ -v "S3_URL" ]]; then

--- a/code/download_data.sh
+++ b/code/download_data.sh
@@ -28,13 +28,13 @@ SD_FILE=us_ssmv11036tS__T0001TTNATS${DATE_DIGITS}*HP001
 
 # Extract files of interest
 gunzip $SD_FILE.dat.gz
-gunzip $SD_FILE.Hdr.gz
+gunzip $SD_FILE.txt.gz
 
 popd
 
 mkdir -p build
 # Create MBTiles from SNODAS Snow Depth
-gdaldem color-relief data/$SD_FILE.Hdr colors.txt build/snow_depth.tiff -of GTiff -alpha
+gdaldem color-relief data/$SD_FILE.txt colors.txt build/snow_depth.tiff -of GTiff -alpha
 gdal_translate build/snow_depth.tiff build/snow_depth.mbtiles -co ZOOM_LEVEL_STRATEGY=upper
 gdaladdo -r average build/snow_depth.mbtiles
 

--- a/code/download_data.sh
+++ b/code/download_data.sh
@@ -39,8 +39,14 @@ gdal_translate build/snow_depth.tiff build/snow_depth.mbtiles -co ZOOM_LEVEL_STR
 gdaladdo -r average build/snow_depth.mbtiles
 
 if [[ -v "S3_URL" ]]; then
+  aws s3 rm --recursive s3://vectortiles-dev.gaiagps.com/us-snow-depth-raster/
   python3 /opt/Processing/upload_mbtiles.py --threads 100 \
       --extension ".png" \
       --header "Cache-Control:max-age=21600" \
-      build/snow_depth.mbtiles $S3_URL
+      build/snow_depth.mbtiles s3://vectortiles-dev.gaiagps.com/us-snow-depth-raster/
+  aws s3 sync \
+      --delete
+      s3://vectortiles-dev.gaiagps.com/us-snow-depth-raster/
+      $S3_URL
+  aws s3 rm --recursive s3://vectortiles-dev.gaiagps.com/us-snow-depth-raster/
 fi

--- a/code/download_data.sh
+++ b/code/download_data.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 # Download SNODAS data
-
+set -e -x
 YEAR=$(date +%Y)
 MONTH_NUM=$(date +%m)
 MONTH_SHORT=$(date +%b)
@@ -9,34 +9,15 @@ DATE_DIGITS=$(date +%Y%m%d)
 # Create URL
 URL=ftp://sidads.colorado.edu/DATASETS/NOAA/G02158/masked/$YEAR/${MONTH_NUM}_${MONTH_SHORT}/SNODAS_${DATE_DIGITS}.tar
 
+mkdir -p data
+pushd data
+
 # Download file from FTP server
 wget $URL
 
-# If file was not found, use yesterday's date
-rc=$?
-if [[ $rc != 0 ]]; then
-
-  YEAR=$(date +%Y --date='yesterday')
-  MONTH_NUM=$(date +%m --date='yesterday')
-  MONTH_SHORT=$(date +%b --date='yesterday')
-  DATE_DIGITS=$(date +%Y%m%d --date='yesterday')
-
-  # Create URL
-  URL=ftp://sidads.colorado.edu/DATASETS/NOAA/G02158/masked/$YEAR/${MONTH_NUM}_${MONTH_SHORT}/SNODAS_${DATE_DIGITS}.tar
-
-  # Download file from FTP server
-  wget $URL
-
-  # If yesterday's data not found, exit
-  rc=$?; if [[ $rc != 0 ]]; then
-    echo "Yesterday's SNODAS data not found"
-    exit $rc
-  fi
-fi
-
 # Saved as SNODAS_YYYYMMDD.tar
 # Extract from tarball
-tar xvf SNODAS_${DATE_DIGITS}.tar
+tar -xvf SNODAS_${DATE_DIGITS}.tar
 
 # Keep only snow depth files
 rm SNODAS_${DATE_DIGITS}.tar
@@ -49,21 +30,17 @@ SD_FILE=us_ssmv11036tS__T0001TTNATS${DATE_DIGITS}*HP001
 gunzip $SD_FILE.dat.gz
 gunzip $SD_FILE.Hdr.gz
 
-mkdir -p ../data/
-mv -f $SD_FILE.dat ../data/
-mv -f $SD_FILE.Hdr ../data/
+popd
 
-# Delete other files
-rm us_ssmv*.gz
-
+mkdir -p build
 # Create MBTiles from SNODAS Snow Depth
-gdaldem color-relief ../data/$SD_FILE.Hdr colors.txt ../data/snow_depth.tiff -of GTiff -alpha
-gdal_translate ../data/snow_depth.tiff ../data/snow_depth.mbtiles
-gdaladdo -r average ../data/snow_depth.mbtiles
+gdaldem color-relief data/$SD_FILE.Hdr colors.txt build/snow_depth.tiff -of GTiff -alpha
+gdal_translate build/snow_depth.tiff build/snow_depth.mbtiles
+gdaladdo -r average build/snow_depth.mbtiles
 
-# Restart docker
-# (This restarts all docker containers)
-docker restart $(docker ps -q)
-
-# Delete all files except the mbtiles
-find ../data/ ! -name 'snow_depth.mbtiles' -type f -exec rm -f {} +
+if [[ -v "S3_URL" ]]; then
+  python3 /opt/Processing/upload_mbtiles.py --threads 100 \
+      --extension ".png" \
+      --header "Cache-Control:max-age=21600" \
+      build/snow_depth.mbtiles $S3_URL
+fi

--- a/code/restart_server.sh
+++ b/code/restart_server.sh
@@ -1,3 +1,0 @@
-#! /usr/bin/env bash
-
-docker restart $(docker ps -q)

--- a/code/start_server.sh
+++ b/code/start_server.sh
@@ -1,3 +1,0 @@
-#! /usr/bin/env bash
-cd ../data/
-docker run -d --rm -it -v $(pwd):/data -p 8080:80 klokantech/tileserver-gl --mbtiles snow_depth.mbtiles --verbose


### PR DESCRIPTION
By uploading to a staging bucket and using `aws s3 sync` we ensure that the production tiles are identical to the most recent generated tiles, including those that had existed in an older version but no longer exist in the most recent generated tiles. 

Closes https://github.com/trailbehind/MapStyles/issues/1109. 